### PR TITLE
Update main.rs

### DIFF
--- a/reflex_updater/src/main.rs
+++ b/reflex_updater/src/main.rs
@@ -221,7 +221,7 @@ fn main_interactive() -> Result<bool> {
     let names: Vec<_> = manifest.iter().map(|x| x.desc.clone()).collect();
     let selection = Select::with_theme(&selection_theme())
         .items(&names)
-        .with_prompt("Select Reflex Firmware (ESC or q to cancel)")
+        .with_prompt("Select Reflex Firmware [ BACK (ESC) or q to cancel ]")
         .default(0)
         .report(false)
         .interact_opt()?;
@@ -254,14 +254,14 @@ fn main() -> Result<()> {
 
     match main_interactive() {
         Ok(true) => {
-            println!("\nSuccess. Press RETURN to exit.");
+            println!("\nSuccess. Press OK (RETURN) to exit.");
             wait_for_return();
             Ok(())
         }
         Ok(false) => Ok(()),
         Err(e) => {
             eprintln!(
-                "\nAn unexpected error was encountered:\n{:#}\n\nPress RETURN to exit.",
+                "\nAn unexpected error was encountered:\n{:#}\n\nPress OK (RETURN) to exit.",
                 e
             );
             wait_for_return();


### PR DESCRIPTION
Favor controller actions of 'Menu: OK' and 'Menu: Back' over traditional keyboard controls.  This 'feels' more in line with a controller adapter, suggesting you can and should use the controller to work with scripts and reflex_updater versus a keyboard.