### PR TITLE
pin serialport-rs to 4.6.1

### DIFF
--- a/reflex_updater/Cargo.toml
+++ b/reflex_updater/Cargo.toml
@@ -11,7 +11,7 @@ console = "0.15"
 dialoguer = "0.10"
 ihex = "3"
 indicatif = "0.17"
-serialport = { version = "4.2", default-features = false }
+serialport = { version = "=4.6.1", default-features = false }
 
 [profile.release]
 strip = true


### PR DESCRIPTION
Tracking problems with serialport-rs in this [issue](https://github.com/misteraddons/Reflex-Adapt/issues/50)

This pull request pins serialport-rs to 4.6.1 as prior to v4.6.0 it breaks on linux and mister and v4.7.0 breaks on windows.