### PR TITLE
Reduces sketch size so >=MPGCombo10 builds again

### DIFF
--- a/ReflexMPG/ReflexMPG.ino
+++ b/ReflexMPG/ReflexMPG.ino
@@ -305,17 +305,17 @@ void configureOutput(InputMode currentMode) {
 #ifdef ENABLE_REFLEX_SATURN
       case RZORD_SATURN:
         display.setCol(2*6);
-        display.print(F("GENESIS + SATURN"));
+        display.print(F("GENESIS+SATURN"));
         break;
 #endif
 #ifdef ENABLE_REFLEX_SNES
       case RZORD_SNES:
         #ifdef SNES_ENABLE_VBOY
           display.setCol(2*6);
-          display.print(F("NES + SNES + VBOY"));
+          display.print(F("NES+SNES+VBOY"));
         #else
           display.setCol(6*6);
-          display.print(F("NES + SNES"));
+          display.print(F("NES+SNES"));
         #endif
         break;
 #endif
@@ -390,10 +390,10 @@ void configureOutput(InputMode currentMode) {
       case RZORD_N64:
         #ifdef N64_ANALOG_MAX
           display.setCol(1*6);
-          display.print(F("N64 EXTENDED RANGE"));
+          display.print(F("N64 MORE RANGE"));
         #else
           display.setCol(1*6);
-          display.print(F("N64 ORIGINAL RANGE"));
+          display.print(F("N64 ORIG RANGE"));
         #endif
         break;
 #endif


### PR DESCRIPTION
https://discord.com/channels/637336939212701757/1082669321555279952/1402210643142115459

> JoseLuis19 — 1:44 AM
Reflex-v2.01.zip doesn't contain all the firmwares


I ran a build locally and reproduced the issue

```
arduino-cli -b Arduino-LUFA:avr:leonardo compile ReflexMPG --build-property "build.extra_flags={build.usb_flags} -DREFLEX_NO_DEFAULTS -DENABLE_REFLEX_SATURN -DENABLE_REFLEX_NEOGEO -DENABLE_REFLEX_N64 -DENABLE_N64_ANALOG_MAX=85 -DENABLE_REFLEX_GAMECUBE" -e --output-dir build/MPGCombo10
Sketch uses 28674 bytes (100%) of program storage space. Maximum is 28672 bytes.
Global variables use 1654 bytes (64%) of dynamic memory, leaving 906 bytes for local variables. Maximum is 2560 bytes.
Sketch too big; see https://support.arduino.cc/hc/en-us/articles/360013825179 for tips on reducing it.
```

MPGCombo10 is 2 bytes too large. I looked around for some optimizations and decided I could reduce the length of some display strings by making them consistent with other strings. I also switched words EXTENDED for MORE and ORIGINAL for ORIG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated OLED display text labels for various device modes to use more concise wording and formatting (e.g., removed spaces around plus signs, shortened certain phrases). No functional changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->