### PR TITLE
Add DualShock 2 analog button support for PS2 emulation

### DIFF
--- a/PS2_Analog_Readme.md
+++ b/PS2_Analog_Readme.md
@@ -1,0 +1,77 @@
+# Reflex Adapt - PS2 Analog Button Support
+
+**DualShock 2 pressure-sensitive button firmware for Reflex-Adapt**
+
+This firmware adds native analog button support for the Sony DualShock 2 controller, enabling pressure-sensitive functionality for Circle, Square, L2, and R2 buttons on via PCSX2 emulation. Rumble is unfortunately not supported due to limitations of D Input, while X Input (which _does_ support rumble) does not support analog face buttons. Go figure!
+
+This firmware was developed specifically for MGS3; it also works well for MGS2. If there's demand I could make another firmware optimized for other games like GTA and Gran Turismo. See below for the technical reasons for this approach.
+
+I have personally tested this firmware using PCSX2 on Windows and Linux; macOS support is implied but not guaranteed. If there's ever a "MiSTer 2" with a PS2 core perhaps it will work there too.
+
+## Features
+
+- **Pressure-Sensitive Buttons**: Circle, Square, L2, R2 with full 0-255 analog range; analog sticks work as expected
+- **Digital Button Preservation**: Triangle, Cross, L1, R1, D-pad, Start, Select, L3, R3 remain digital
+- **PCSX2 Compatible**: Proper pressure value inversion for PCSX2
+- **Game-Optimized**: Optimized for MGS3 (and MGS2), see below.
+- **OLED Display**: Clear "PS2 ANALOG" firmware identification, buttons light up when pressed
+
+## Technical Implementation
+
+### HID Axis Allocation
+
+The DualShock 2 reports all face buttons and shoulders as pressure-sensitive (0–255). However, USB HID gamepads on Windows are effectively limited to 8 analog axes (X, Y, Z, Rx, Ry, Rz, Slider1, Slider2). 
+
+After mapping both analog sticks (4 axes), only 4 remain. These are strategically assigned for MGS3:
+
+**Analog Buttons:**
+- **Square** - Gun control
+- **Circle** - CQC  
+- **L2** - Item menu feathering
+- **R2** - Weapon menu feathering
+
+**Digital Buttons:**
+- All other buttons (D-pad, △, ×, L1, R1, L3, R3, Start, Select) mapped as digital
+
+This design preserves critical analog behavior while staying within HID axis limits.
+
+## Installation
+
+1. Use the [Reflex-Adapt updater tool](https://github.com/misteraddons/Reflex-Adapt) to flash the MGS23.hex firmware
+2. Connect your DualShock 2 controller to the Reflex-Adapt
+3. The OLED display will show "PS2 ANALOG" to confirm the specialized firmware is loaded
+
+## Building from Source
+
+1. Follow the [main Reflex-Adapt build instructions](https://github.com/misteraddons/Reflex-Adapt#building-firmware-on-linux)
+2. Use the modified source files in this repository
+3. Build with: `make MGS23`
+4. The compiled firmware will be available as `firmware/MGS23.hex`
+
+## Technical Details
+
+- **Memory Usage**: 68% flash (19,506 bytes), 53% RAM (1,361 bytes)
+- **Pressure Resolution**: Full 8-bit (0-255) analog range
+- **PCSX2 Compatibility**: Automatic pressure value inversion (255 - value)
+- **Specialized Architecture**: PS2-only firmware for optimal performance
+
+## Files Modified
+
+- `ReflexMPG/Input_Psx.h` - DualShock 2 input handling and analog button enablement
+- `ReflexMPG/src/MPG/MPG.cpp` - HID report generation and button mapping
+- `ReflexMPG/ReflexMPG.ino` - OLED display enhancement
+- `manifest.txt` - Firmware distribution configuration
+- `Makefile` - Added MGS23 build target for Metal Gear Solid optimized firmware
+
+## License
+
+Same as main Reflex-Adapt project.
+
+## Author
+
+Created by Nicholas De Leon // github.com/daylayown // nicholas@daylayown.org // @nicholasadeleon (X and Bluesky)
+
+## Credits
+
+Reflex-Adapt by MisterAddons (github.com/misteraddons)
+PsxNewLib by SukkoPera (github.com/SukkoPera)

--- a/ReflexMPG/Input_Psx.h
+++ b/ReflexMPG/Input_Psx.h
@@ -55,39 +55,22 @@ class ReflexInputPsx : public RZInputModule {
       new PsxControllerHwSpi<PIN_PS2_ATT>()
     };
 
-    bool isNeGcon { false };
-    bool isJogcon { false };
-    bool isGuncon { false };
-    bool isNeGconMiSTer { false };
-    uint8_t specialDpadMask { 0x0 };
     bool haveController[2] { false, false };
     PsxControllerProtocol lastProto[2] { PSPROTO_UNKNOWN, PSPROTO_UNKNOWN };
-    bool enableMouseMove { false }; //used on guncon and jogcon modes
     uint8_t outputIndex { 0 };
 
     void tryEnableRumble() {
-      //if ((options.inputMode == INPUT_MODE_XINPUT || detectDS2) && !isJogcon){ //try to enable rumble
-      if (!isJogcon){ //try to enable rumble
-        if (psx->enterConfigMode ()) {
-          psx->enableRumble ();
-          if (psx->getControllerType () == PSCTRL_DUALSHOCK2) {
-            sleepTime = PS_INTERVAL_DS2;
-          }
-          psx->exitConfigMode ();
+      if (psx->enterConfigMode()) {
+        psx->enableRumble();
+        psx->enableAnalogButtons();
+        if (psx->getControllerType() == PSCTRL_DUALSHOCK2) {
+          sleepTime = PS_INTERVAL_DS2;
         }
+        psx->exitConfigMode();
       }
     }
 
-    //Include sub-modules as private
-    #ifdef GUNCON_SUPPORT
-      #include "Input_Psx_Guncon.h"
-    #endif
-    #ifdef NEGCON_SUPPORT
-      #include "Input_Psx_Negcon.h"
-    #endif
-    #ifdef JOGCON_SUPPORT
-      #include "Input_Psx_Jogcon.h"
-    #endif
+    // PS2 Analog firmware - specialized for DualShock 2 pressure-sensitive buttons
 
     #ifdef ENABLE_REFLEX_PAD
       const Pad padPsx[16] = {
@@ -124,66 +107,48 @@ class ReflexInputPsx : public RZInputModule {
       };
     
       void loopPadDisplayCharsPsx(const uint8_t index, const PsxControllerProtocol padType, void* p, const bool force) {
-//        for(uint8_t i = 0; i < (sizeof(padPsx) / sizeof(Pad)); ++i){
-//          if(padType != PSPROTO_DUALSHOCK && padType != PSPROTO_DUALSHOCK2 && (i == 1 || i == 2))
-//            continue;
-//          if(padType == PSPROTO_NEGCON && (i == 0 || i == 8 || i == 9))
-//            continue;
-//          const Pad pad = padPsx[i];
-//          PrintPadChar(index, padDivision[index].firstCol, pad.col, pad.row, pad.padvalue, p && static_cast<PsxController*>(p)->buttonPressed(static_cast<PsxButton>(pad.padvalue)), pad.on, pad.off, force);
-//        }
-        if(specialDpadMask == SPECIALMASK_POPN) {
-          for(uint8_t i = 0; i < (sizeof(padPsxPopN) / sizeof(Pad)); ++i){
-            const Pad pad = padPsxPopN[i];
-            PrintPadChar(index, padDivision[index].firstCol, pad.col, pad.row, pad.padvalue, p && static_cast<PsxController*>(p)->buttonPressed(static_cast<PsxButton>(pad.padvalue)), pad.on, pad.off, force);
-          }
-        } else {
-          for(uint8_t i = 0; i < (sizeof(padPsx) / sizeof(Pad)); ++i){
-            if(padType != PSPROTO_DUALSHOCK && padType != PSPROTO_DUALSHOCK2 && (i == 1 || i == 2))
-              continue;
-            if(padType == PSPROTO_NEGCON && (i == 0 || i == 8 || i == 9))
-              continue;
-            const Pad pad = padPsx[i];
-            PrintPadChar(index, padDivision[index].firstCol, pad.col, pad.row, pad.padvalue, p && static_cast<PsxController*>(p)->buttonPressed(static_cast<PsxButton>(pad.padvalue)), pad.on, pad.off, force);
-          }
+        // Show all DS2 buttons
+        for(uint8_t i = 0; i < (sizeof(padPsx) / sizeof(Pad)); ++i){
+          const Pad pad = padPsx[i];
+          PrintPadChar(index, padDivision[index].firstCol, pad.col, pad.row, pad.padvalue, p && static_cast<PsxController*>(p)->buttonPressed(static_cast<PsxButton>(pad.padvalue)), pad.on, pad.off, force);
+        }
       }
-    }
     
       void ShowDefaultPadPsx(const uint8_t index, const PsxControllerProtocol padType) {
         display.clear(padDivision[index].firstCol, padDivision[index].lastCol, oledDisplayFirstRow + 1, 7);
         display.setCursor(padDivision[index].firstCol, 7);
     
+        // Show protocol type and analog button availability
         switch(padType) {
-          case PSPROTO_DIGITAL:
-          case PSPROTO_NEGCON:
-            if (specialDpadMask == SPECIALMASK_POPN)
-              display.print(F("POP N"));
-            else
-              display.print(isNeGcon ? F("NEGCON") : PSTR_TO_F(PSTR_DIGITAL));
+          case PSPROTO_DUALSHOCK2:
+            display.print(F("DS2"));
             break;
           case PSPROTO_DUALSHOCK:
-            if (specialDpadMask == SPECIALMASK_JET){
-              display.print(F("JET"));
-            } else {
-              display.print(F("DUALSHOCK"));
-            }
+            display.print(F("DS1"));
             break;
-          //case PSPROTO_DUALSHOCK2:
-          //  display.print(F("DUALSHOCK2"));
-          //  break;
+          case PSPROTO_DIGITAL:
+            display.print(F("DIG"));
+            break;
           case PSPROTO_FLIGHTSTICK:
-            display.print(F("FLIGHTSTICK"));
+            display.print(F("FLY"));
             break;
-          //case PSPROTO_NEGCON:
-          //  display.print(F("NEGCON-"));
-          //  display.print(isNeGcon ? F("ANALOG") : PSTR_TO_F(PSTR_DIGITAL));
-          //  break;
+          case PSPROTO_NEGCON:
+            display.print(F("NEG"));
+            break;
           case PSPROTO_JOGCON:
-            display.print(F("JOGCON"));
+            display.print(F("JOG"));
+            break;
+          case PSPROTO_GUNCON:
+            display.print(F("GUN"));
             break;
           default:
             display.print(PSTR_TO_F(PSTR_NONE));
             return;
+        }
+        
+        // Show if analog button data is available
+        if (psx && psx->getAnalogButtonData() != nullptr) {
+          display.print(F("+"));  // Indicates analog button data available
         }
       
         if (index < 2) {
@@ -199,8 +164,6 @@ class ReflexInputPsx : public RZInputModule {
         | (psx->buttonPressed(PSB_PAD_LEFT)  ? GAMEPAD_MASK_LEFT  : 0)
         | (psx->buttonPressed(PSB_PAD_RIGHT) ? GAMEPAD_MASK_RIGHT : 0)
       ;
-      if (specialDpadMask)
-        state[outputIndex].dpad = (state[outputIndex].dpad | specialDpadMask) & 0xF;
     }
 
     bool loopDualShock() {
@@ -232,38 +195,31 @@ class ReflexInputPsx : public RZInputModule {
     
       
       switch (proto) {
-      case PSPROTO_DIGITAL:
-        //if (!stateChanged)
-        //  return false;
-      case PSPROTO_NEGCON:
       case PSPROTO_DUALSHOCK:
       case PSPROTO_DUALSHOCK2:
-      case PSPROTO_FLIGHTSTICK:
       {
         handleDpad();
     
 //        uint16_t buttonData = 0;
-        //controller buttons
+        // Controller buttons - Triangle and Cross remain digital, Circle/Square/L2/R2 are analog
+        const uint8_t* analogData = psx->getAnalogButtonData();
+        
         state[outputIndex].buttons = 0
-          | (psx->buttonPressed(PSB_CROSS)    ? GAMEPAD_MASK_B1 : 0) // Generic: K1, Switch: B, Xbox: A
-          | (psx->buttonPressed(PSB_CIRCLE)   ? GAMEPAD_MASK_B2 : 0) // Generic: K2, Switch: A, Xbox: B
-          | (psx->buttonPressed(PSB_SQUARE)   ? GAMEPAD_MASK_B3 : 0) // Generic: P1, Switch: Y, Xbox: X
-          | (psx->buttonPressed(PSB_TRIANGLE) ? GAMEPAD_MASK_B4 : 0) // Generic: P2, Switch: X, Xbox: Y
-          | (psx->buttonPressed(PSB_L1)       ? GAMEPAD_MASK_L1 : 0) // Generic: P4, Switch: L, Xbox: LB
-          | (psx->buttonPressed(PSB_R1)       ? GAMEPAD_MASK_R1 : 0) // Generic: P3, Switch: R, Xbox: RB
-          | (psx->buttonPressed(PSB_L2)       ? GAMEPAD_MASK_L2 : 0) // Generic: K4, Switch: ZL, Xbox: LT (Digital)
-          | (psx->buttonPressed(PSB_R2)       ? GAMEPAD_MASK_R2 : 0) // Generic: K3, Switch: ZR, Xbox: RT (Digital)
-          | (psx->buttonPressed(PSB_SELECT)   ? GAMEPAD_MASK_S1 : 0) // Generic: Select, Switch: -, Xbox: View
-          | (psx->buttonPressed(PSB_START)    ? GAMEPAD_MASK_S2 : 0) // Generic: Start, Switch: +, Xbox: Menu
-          | (psx->buttonPressed(PSB_L3)       ? GAMEPAD_MASK_L3 : 0) // All: Left Stick Click
-          | (psx->buttonPressed(PSB_R3)       ? GAMEPAD_MASK_R3 : 0) // All: Right Stick Click
+          | (psx->buttonPressed(PSB_TRIANGLE) ? GAMEPAD_MASK_B4 : 0)
+          | (psx->buttonPressed(PSB_CROSS)    ? GAMEPAD_MASK_B1 : 0)
+          | (psx->buttonPressed(PSB_L1)       ? GAMEPAD_MASK_L1 : 0)
+          | (psx->buttonPressed(PSB_R1)       ? GAMEPAD_MASK_R1 : 0)
+          | (psx->buttonPressed(PSB_SELECT)   ? GAMEPAD_MASK_S1 : 0)
+          | (psx->buttonPressed(PSB_START)    ? GAMEPAD_MASK_S2 : 0)
+          | (psx->buttonPressed(PSB_L3)       ? GAMEPAD_MASK_L3 : 0)
+          | (psx->buttonPressed(PSB_R3)       ? GAMEPAD_MASK_R3 : 0)
         ;
     
     
     //if(proto != PSPROTO_DIGITAL)
     
         //analog sticks
-        if (psx->getLeftAnalog(analogX, analogY) && proto != PSPROTO_NEGCON) {
+        if (psx->getLeftAnalog(analogX, analogY)) {
           state[outputIndex].lx = convertAnalog(analogX);
           state[outputIndex].ly = convertAnalog(analogY);
         } else {
@@ -279,9 +235,30 @@ class ReflexInputPsx : public RZInputModule {
         lastLX[outputIndex] = analogX;
         lastLY[outputIndex] = analogY;
     
-        if (psx->getRightAnalog(analogX, analogY) && proto != PSPROTO_NEGCON) {
-          if (specialDpadMask == SPECIALMASK_JET)
-            analogX = ANALOG_IDLE_VALUE;
+        // Read pressure data for analog buttons
+        if (analogData != nullptr) {
+          state[outputIndex].pressureCircle = analogData[5];
+          state[outputIndex].pressureSquare = analogData[7];
+          state[outputIndex].pressureL2 = analogData[10];
+          state[outputIndex].pressureR2 = analogData[11];
+        } else {
+          state[outputIndex].pressureCircle = 0;
+          state[outputIndex].pressureSquare = 0;
+          state[outputIndex].pressureL2 = 0;
+          state[outputIndex].pressureR2 = 0;
+        }
+        
+        state[outputIndex].pressureRight = 0;
+        state[outputIndex].pressureLeft = 0;
+        state[outputIndex].pressureUp = 0;
+        state[outputIndex].pressureDown = 0;
+        state[outputIndex].pressureL1 = 0;
+        state[outputIndex].pressureR1 = 0;
+        state[outputIndex].pressureTriangle = 0;
+        state[outputIndex].pressureCross = 0;
+        
+        // Handle right analog stick normally
+        if (psx->getRightAnalog(analogX, analogY)) {
           state[outputIndex].rx = convertAnalog(analogX);
           state[outputIndex].ry = convertAnalog(analogY);
         } else {
@@ -290,7 +267,8 @@ class ReflexInputPsx : public RZInputModule {
           state[outputIndex].rx = convertAnalog(analogX);
           state[outputIndex].ry = convertAnalog(analogY);
         }
-        
+
+
         if (lastRX[outputIndex] != analogX || lastRY[outputIndex] != analogY)
           stateChanged = true;
     
@@ -329,23 +307,10 @@ class ReflexInputPsx : public RZInputModule {
   public:
     ReflexInputPsx() : RZInputModule() { }
 
+
     const char* getUsbId() override {
-      static const char* usbId_ds1       { "RZMPsDS1" };
-      static const char* usbId_guncon    { "ReflexPSGun" }; //{ "RZordPsGun" };
-      static const char* usbId_negcon    { "RZMPsNeGcon" };
-      //static const char* usbId_negwheel { "RZordPsWheel" }; //{ "RZMPsWheel" };
-      static const char* usbId_negwheel  { "ReflexPSWheel" }; //{ "RZMPsWheel" };
-      static const char* usbId_misterjog { "MiSTer-A1 JogCon" };
-      static const char* usbId_mousejog  { "RZMPSJogCon" };
-      
-      if (isGuncon)
-        return usbId_guncon;
-      else if (isNeGcon)
-        return isNeGconMiSTer ? usbId_negwheel : usbId_negcon;
-      else if (isJogcon)
-        return enableMouseMove ? usbId_mousejog : usbId_misterjog;
-      else
-        return usbId_ds1;
+      static const char* usbId_ds2 { "RZMPsDS2" };
+      return usbId_ds2;
     }
 
     const uint16_t getUsbVersion() override {
@@ -391,110 +356,25 @@ class ReflexInputPsx : public RZInputModule {
 
         lastProto[0] = proto;
     
-        if (proto == PSPROTO_GUNCON) {
-          isGuncon = true;
-        } else if (proto == PSPROTO_NEGCON) {
-          isNeGcon = true;
-    
-          //Configure NeGcon mode
-          #if defined(NEGCON_FORCE_MODE) && NEGCON_FORCE_MODE >= 0 && NEGCON_FORCE_MODE < 2
-            #if NEGCON_FORCE_MODE == 1
-              isNeGconMiSTer = true;
-            #endif
-          #else //NEGCON_FORCE_MODE
-            if (psx->buttonPressed(PSB_CIRCLE)) //NeGcon A / Volume B
-              isNeGconMiSTer = !isNeGconMiSTer;
-          #endif //NEGCON_FORCE_MODE
-        } else { //jogcon can't be detected during boot as it needs to be in analog mode
-    
-    #ifdef JOGCON_SUPPORT
-        //Try to detect by it's id
-        if(proto == PSPROTO_DIGITAL) {
-          if (psx->enterConfigMode ()) {
-            if (psx->getControllerType () == PSCTRL_JOGCON) {
-              isJogcon = true;
-              if (psx->buttonPressed(PSB_L2))
-                enableMouseMove = true;
-            }
-            psx->exitConfigMode ();
-          }
-        }
-    #endif
-
-          if (psx->buttonPressed(PSB_SELECT)) { //dualshock used in guncon mode to help map axis on emulators.
-            isGuncon = true;
-          }
-          /*else if (proto == PSPROTO_JOGCON || psx->buttonPressed(PSB_L1)) {
-            isJogcon = true;
-          } else if (psx->buttonPressed(PSB_L2)) {
-            isJogcon = true;
-            enableMouseMove = true;
-          }*/
-        }
+        // Only support DualShock 2 controllers
 
         tryEnableRumble();
 
 
       } else { //no controller connected
-        if (proto == PSPROTO_JOGCON)
-          isJogcon = true;
+        // DS2 only - no special controller handling
       }
     
-      if (isNeGcon) {
-        #ifdef NEGCON_SUPPORT
-          negconSetup();
-        #endif
-      } else if (isJogcon) {
-        #ifdef JOGCON_SUPPORT
-          jogconSetup();
-        #endif
-      } else {
-        if (isGuncon) {
-          #ifdef GUNCON_SUPPORT
-            gunconSetup();
-          #endif
-        } else { //dualshock [default]
-          
-          if (proto == PSPROTO_DIGITAL
-          && psx->buttonPressed(PSB_PAD_DOWN)
-          && psx->buttonPressed(PSB_PAD_LEFT)
-          && psx->buttonPressed(PSB_PAD_RIGHT))
-            specialDpadMask = SPECIALMASK_POPN;
-
-          if (proto == PSPROTO_DUALSHOCK
-          && psx->buttonPressed(PSB_PAD_LEFT)
-          && psx->buttonPressed(PSB_PAD_RIGHT)) {
-            byte analogX;
-            byte analogY;
-            if (psx->getRightAnalog(analogX, analogY) && analogX == 0xFF) {
-              sleepTime = PS_INTERVAL_JET;
-              specialDpadMask = SPECIALMASK_JET;
-            }
-          }
-            
-          totalUsb = 2;//MAX_USB_STICKS;
-          for (uint8_t i = 0; i < totalUsb; i++) {
-            hasLeftAnalogStick[i] = true;
-            hasRightAnalogStick[i] = true;
-          }
-        }
+      // DualShock 2 setup
+      totalUsb = 2;//MAX_USB_STICKS;
+      for (uint8_t i = 0; i < totalUsb; i++) {
+        hasLeftAnalogStick[i] = true;
+        hasRightAnalogStick[i] = true;
       }
     }//end setup
 
     void setup2() override {
-      if (isNeGcon) {
-        #ifdef NEGCON_SUPPORT
-          negconSetup2();
-        #endif
-      } else if (isJogcon) {
-        #ifdef JOGCON_SUPPORT
-          jogconSetup2();
-        #endif
-      } else if (isGuncon) {
-        #ifdef GUNCON_SUPPORT
-          gunconSetup2();
-        #endif
-      }
+      // DualShock 2 setup - nothing needed
     }
 
     bool read() override {
@@ -504,21 +384,7 @@ class ReflexInputPsx : public RZInputModule {
     
       outputIndex = 0;
     
-      if(isJogcon) {
-        #ifdef JOGCON_SUPPORT
-          if (!haveController[0]) {
-            init_jogcon();
-          } else {
-            if(!psx->read()){
-              //haveController = false;
-              haveController[0] = false;
-            } else {
-              stateChanged = handleJogconData();
-            }
-          }
-        #endif
-        return stateChanged;//haveController[0];
-      }
+      // DualShock 2 only - no special controller handling needed
     
       //if (millis() - last >= POLLING_INTERVAL) {
       //  last = millis();
@@ -551,6 +417,9 @@ class ReflexInputPsx : public RZInputModule {
           display.clear(0, 127, 7, 7);
           display.setRow(7);
     
+          // Show firmware identifier
+          display.setCol(0);
+          display.print(F("DS2 FW"));
     
           for (uint8_t i = 0; i < 2; i++) {
             //const uint8_t firstCol = i == 0 ? 0 : 12*6;
@@ -625,25 +494,14 @@ class ReflexInputPsx : public RZInputModule {
               ShowDefaultPadPsx(i, PSPROTO_UNKNOWN);
             }
           }
-          if(isGuncon)//only use first port for guncon
-            break;
+          // DS2 supports both ports
         }
     
     
         for (uint8_t i = 0; i < totalUsb; i++) {
           if (haveController[i] && isReadSuccess[i]) {
             psx = psxlist[i];
-            if (isNeGcon) {
-              #ifdef NEGCON_SUPPORT
-                stateChanged |= loopNeGcon();
-              #endif
-            } else if (isGuncon) {
-              #ifdef GUNCON_SUPPORT
-                loopGuncon();
-              #endif
-            } else {
-              stateChanged |= loopDualShock();
-            }
+            stateChanged |= loopDualShock();
           }
           outputIndex++;
         }

--- a/ReflexMPG/ReflexMPG.ino
+++ b/ReflexMPG/ReflexMPG.ino
@@ -17,7 +17,7 @@
 // DONT USE THIS. ENABLE MODES DOWN BELOW AT REFLEX_NO_DEFAULTS
 //#define ENABLE_REFLEX_SATURN
 //#define ENABLE_REFLEX_SNES
-//#define ENABLE_REFLEX_PSX
+#define ENABLE_REFLEX_PSX
 //#define ENABLE_REFLEX_PSX_JOG //this is for jogcon forced specific mode. jogcon can still be used with ENABLE_REFLEX_PSX
 //#define ENABLE_REFLEX_PCE
 //#define ENABLE_REFLEX_NEOGEO
@@ -157,6 +157,7 @@
 #include "Shared.h"
 
 #include <LUFA.h>
+#include "USBAPI.h"  // Ensure Serial is available
 #include "LUFADriver.h"
 
 // Define time function for gamepad debouncer
@@ -204,6 +205,9 @@ static_assert( (RZORD_LAST > 1), "Error: must enable at least one input module")
 
 RZInputModule* gamepadModule; // gamepad(DEBOUNCE_MILLIS); // The gamepad instance
 
+// Global bypass array for perfect DS2 pressure data
+uint8_t ds2PressureBypass[12] = {0};
+
 char USB_STRING_MANUFACTURER[] = "MiSTerAddons";
 char USB_STRING_PRODUCT[] = "Reflex Adapt";
 //char USB_STRING_VERSION[] = "1.0";
@@ -218,8 +222,8 @@ void printModeByIndex(const InputMode i) {
     display.print(F("XINPUT"));
   } else if (i == INPUT_MODE_SWITCH) {
     display.print(F("SWITCH"));
-//  } else if (i == INPUT_MODE_PS3) {
-//    display.print(F("PS3"));
+  } else if (i == INPUT_MODE_PS3) {
+    display.print(F("PS3"));
   } else if (i >= INPUT_MODE_HID && i < INPUT_MODE_LAST) {
     display.print(F("HID"));
   } else {
@@ -285,7 +289,7 @@ void configureOutput(InputMode currentMode) {
         if(!firstRun) {
           currentMode = (InputMode)(currentMode + 1);
 
-          if(currentMode > INPUT_MODE_HID) //LAST
+          if(currentMode >= INPUT_MODE_LAST) //LAST
             currentMode = (InputMode)0;
         }
         display.clear(0, 127, 5, 7);
@@ -344,18 +348,8 @@ void configureOutput(InputMode currentMode) {
             psxchars -= 2;
           #endif
 
-          display.setCol(psxchars*6);
-          display.print(F("PSX"));
-
-          #ifdef GUNCON_SUPPORT
-            display.print(F("+GUN"));
-          #endif
-          #ifdef JOGCON_SUPPORT
-            display.print(F("+JOG"));
-          #endif
-          #ifdef NEGCON_SUPPORT
-            display.print(F("+NEG"));
-          #endif
+          display.setCol(4*6);
+          display.print(F("PS2 ANALOG"));
         }
 #endif //end general psx mode
 
@@ -566,6 +560,15 @@ void setup() {
 //gamepadModule->options.inputMode = INPUT_MODE_XINPUT;
 //gamepadModule->options.inputMode = INPUT_MODE_HID;
 //gamepadModule->options.inputMode = INPUT_MODE_SWITCH;
+#ifdef ENABLE_DS2_PS3_MODE
+  gamepadModule->options.inputMode = INPUT_MODE_PS3;
+#endif
+#ifdef ENABLE_PSX_GENERAL_OLED
+  #ifndef ENABLE_DS2_PS3_MODE
+    // Force HID mode for PS2_Analog firmware
+    gamepadModule->options.inputMode = INPUT_MODE_HID;
+  #endif
+#endif
 
   configureOutput(gamepadModule->options.inputMode);
 
@@ -621,8 +624,8 @@ void setup() {
     display.print('X');
   } else if (gamepadModule->options.inputMode == INPUT_MODE_SWITCH) {
     display.print('S');
-//  } else if (gamepadModule->options.inputMode == INPUT_MODE_PS3) {
-//    display.print('P');
+  } else if (gamepadModule->options.inputMode == INPUT_MODE_PS3) {
+    display.print('P');
   } else if (gamepadModule->options.inputMode == INPUT_MODE_HID) {
     display.print('H');
   } else if (gamepadModule->options.inputMode == INPUT_MODE_HID_GUNCON
@@ -676,13 +679,14 @@ void loop() {
 //  display.println( gamepadModule->state[0].rt );
 //  delay(2);
 
-  if (ps3enabled) {
-    ps3enabled = false;
-    gamepadModule->isPS3 = true;
-    display.setRow(1);
-    display.setCol(0);
-    display.print('P');
-  }
+  // Removed PS3 detection display code to prevent 'P' showing in HID mode
+  // if (ps3enabled) {
+  //   ps3enabled = false;
+  //   gamepadModule->isPS3 = true;
+  //   display.setRow(1);
+  //   display.setCol(0);
+  //   display.print('P');
+  // }
 
   //Disable oled display after 2 minutes of no state changed
   //Any input state change will wake up the display

--- a/ReflexMPG/src/MPG/MPG.cpp
+++ b/ReflexMPG/src/MPG/MPG.cpp
@@ -5,17 +5,17 @@
 
 #include "MPG.h"
 
-// static PS3Report ps3Report
-// {
-// 	.square_btn = 0, .cross_btn = 0, .circle_btn = 0, .triangle_btn = 0,
-// 	.l1_btn = 0, .r1_btn = 0, .l2_btn = 0, .r2_btn = 0,
-// 	.select_btn = 0, .start_btn = 0, .l3_btn = 0, .r3_btn = 0, .ps_btn = 0,
-// 	.direction = 0x08,
-// 	.l_x_axis = 0x80, .l_y_axis = 0x80, .r_x_axis = 0x80, .r_y_axis = 0x80,
-// 	.right_axis = 0x00, .left_axis = 0x00, .up_axis = 0x00, .down_axis = 0x00,
-// 	.triangle_axis = 0x00, .circle_axis = 0x00, .cross_axis = 0x00, .square_axis = 0x00,
-// 	.l1_axis = 0x00, .r1_axis = 0x00, .l2_axis = 0x00, .r2_axis = 0x00
-// };
+static PS3Report ps3Report
+{
+	.square_btn = 0, .cross_btn = 0, .circle_btn = 0, .triangle_btn = 0,
+	.l1_btn = 0, .r1_btn = 0, .l2_btn = 0, .r2_btn = 0,
+	.select_btn = 0, .start_btn = 0, .l3_btn = 0, .r3_btn = 0, .ps_btn = 0,
+	.direction = 0x08,
+	.l_x_axis = 0x80, .l_y_axis = 0x80, .r_x_axis = 0x80, .r_y_axis = 0x80,
+	.right_axis = 0x00, .left_axis = 0x00, .up_axis = 0x00, .down_axis = 0x00,
+	.triangle_axis = 0x00, .circle_axis = 0x00, .cross_axis = 0x00, .square_axis = 0x00,
+	.l1_axis = 0x00, .r1_axis = 0x00, .l2_axis = 0x00, .r2_axis = 0x00
+};
 
 static HIDReport hidReport
 {
@@ -113,8 +113,8 @@ void *MPG::getReport(const uint8_t index)
 		case INPUT_MODE_SWITCH:
 			return getSwitchReport(index);
 
-		// case INPUT_MODE_PS3:
-		// 	return getPS3Report(index);
+		case INPUT_MODE_PS3:
+			return getPS3Report(index);
 
 		case INPUT_MODE_HID_NEGCON:
 			return getNegconReport(index);
@@ -149,8 +149,8 @@ uint16_t MPG::getReportSize(const uint8_t index)
 		case INPUT_MODE_SWITCH:
 			return sizeof(SwitchReport);
 
-		// case INPUT_MODE_PS3:
-		// 	return sizeof(PS3Report);
+		case INPUT_MODE_PS3:
+			return sizeof(PS3Report);
 
 		case INPUT_MODE_HID_NEGCON:
 			return sizeof(NegconReport);
@@ -175,54 +175,70 @@ uint16_t MPG::getReportSize(const uint8_t index)
 }
 
 
-// PS3Report *MPG::getPS3Report(const uint8_t index)
-// {
-// 	switch (state[index].dpad & GAMEPAD_MASK_DPAD)
-// 	{
-// 		case GAMEPAD_MASK_UP:                        ps3Report.direction = HID_HAT_UP;        break;
-// 		case GAMEPAD_MASK_UP | GAMEPAD_MASK_RIGHT:   ps3Report.direction = HID_HAT_UPRIGHT;   break;
-// 		case GAMEPAD_MASK_RIGHT:                     ps3Report.direction = HID_HAT_RIGHT;     break;
-// 		case GAMEPAD_MASK_DOWN | GAMEPAD_MASK_RIGHT: ps3Report.direction = HID_HAT_DOWNRIGHT; break;
-// 		case GAMEPAD_MASK_DOWN:                      ps3Report.direction = HID_HAT_DOWN;      break;
-// 		case GAMEPAD_MASK_DOWN | GAMEPAD_MASK_LEFT:  ps3Report.direction = HID_HAT_DOWNLEFT;  break;
-// 		case GAMEPAD_MASK_LEFT:                      ps3Report.direction = HID_HAT_LEFT;      break;
-// 		case GAMEPAD_MASK_UP | GAMEPAD_MASK_LEFT:    ps3Report.direction = HID_HAT_UPLEFT;    break;
-// 		default:                                     ps3Report.direction = HID_HAT_NOTHING;   break;
-// 	}
+PS3Report *MPG::getPS3Report(const uint8_t index)
+{
+	// Handle D-pad direction
+	switch (state[index].dpad & GAMEPAD_MASK_DPAD)
+	{
+		case GAMEPAD_MASK_UP:                        ps3Report.direction = HID_HAT_UP;        break;
+		case GAMEPAD_MASK_UP | GAMEPAD_MASK_RIGHT:   ps3Report.direction = HID_HAT_UPRIGHT;   break;
+		case GAMEPAD_MASK_RIGHT:                     ps3Report.direction = HID_HAT_RIGHT;     break;
+		case GAMEPAD_MASK_DOWN | GAMEPAD_MASK_RIGHT: ps3Report.direction = HID_HAT_DOWNRIGHT; break;
+		case GAMEPAD_MASK_DOWN:                      ps3Report.direction = HID_HAT_DOWN;      break;
+		case GAMEPAD_MASK_DOWN | GAMEPAD_MASK_LEFT:  ps3Report.direction = HID_HAT_DOWNLEFT;  break;
+		case GAMEPAD_MASK_LEFT:                      ps3Report.direction = HID_HAT_LEFT;      break;
+		case GAMEPAD_MASK_UP | GAMEPAD_MASK_LEFT:    ps3Report.direction = HID_HAT_UPLEFT;    break;
+		default:                                     ps3Report.direction = HID_HAT_NOTHING;   break;
+	}
 
-// 	ps3Report.cross_btn    = pressedB1(index);
-// 	ps3Report.circle_btn   = pressedB2(index);
-// 	ps3Report.square_btn   = pressedB3(index);
-// 	ps3Report.triangle_btn = pressedB4(index);
-// 	ps3Report.l1_btn       = pressedL1(index);
-// 	ps3Report.r1_btn       = pressedR1(index);
-// 	ps3Report.l2_btn       = pressedL2(index);
-// 	ps3Report.r2_btn       = pressedR2(index);
-// 	ps3Report.select_btn   = pressedS1(index);
-// 	ps3Report.start_btn    = pressedS2(index);
-// 	ps3Report.l3_btn       = pressedL3(index);
-// 	ps3Report.r3_btn       = pressedR3(index);
-// 	ps3Report.ps_btn       = pressedA1(index);
-// //	ps3Report.cross_btn = pressedA2();
+	// Digital button mapping - only for non-analog buttons
+	ps3Report.select_btn   = pressedS1(index);
+	ps3Report.start_btn    = pressedS2(index);
+	ps3Report.l3_btn       = pressedL3(index);
+	ps3Report.r3_btn       = pressedR3(index);
+	ps3Report.ps_btn       = pressedA1(index);
 
-// 	ps3Report.l_x_axis = static_cast<uint8_t>(state[index].lx >> 8);
-// 	ps3Report.l_y_axis = static_cast<uint8_t>(state[index].ly >> 8);
-// 	ps3Report.r_x_axis = static_cast<uint8_t>(state[index].rx >> 8);
-// 	ps3Report.r_y_axis = static_cast<uint8_t>(state[index].ry >> 8);
+	// Analog sticks (standard mapping)
+	ps3Report.l_x_axis = static_cast<uint8_t>(state[index].lx >> 8);
+	ps3Report.l_y_axis = static_cast<uint8_t>(state[index].ly >> 8);
+	ps3Report.r_x_axis = static_cast<uint8_t>(state[index].rx >> 8);
+	ps3Report.r_y_axis = static_cast<uint8_t>(state[index].ry >> 8);
 
-// 	if (hasAnalogTriggers[index])
-// 	{
-// 		ps3Report.l2_axis = state[index].lt;
-// 		ps3Report.r2_axis = state[index].rt;
-// 	}
-// 	else
-// 	{
-// 		ps3Report.l2_axis = pressedL2(index) * 0xFF;
-// 		ps3Report.r2_axis = pressedR2(index) * 0xFF;
-// 	}
+	// DS2→PS3 FULL ANALOG BUTTON MAPPING
+	// Map all 12 DS2 pressure buttons to PS3 analog fields
+	// DS2 order: R, L, Up, Down, Triangle, Circle, Cross, Square, L1, R1, L2, R2
 
-// 	return &ps3Report;
-// }
+	// D-pad analog values (indices 0-3)
+	ps3Report.right_axis = state[index].pressureRight;
+	ps3Report.left_axis = state[index].pressureLeft;
+	ps3Report.up_axis = state[index].pressureUp;
+	ps3Report.down_axis = state[index].pressureDown;
+
+	// Face button analog values (indices 4-7)
+	ps3Report.triangle_axis = state[index].pressureTriangle;
+	ps3Report.circle_axis = state[index].pressureCircle;
+	ps3Report.cross_axis = state[index].pressureCross;
+	ps3Report.square_axis = state[index].pressureSquare;
+
+	// Shoulder button analog values (indices 8-11)
+	ps3Report.l1_axis = state[index].pressureL1;
+	ps3Report.r1_axis = state[index].pressureR1;
+	ps3Report.l2_axis = state[index].pressureL2;
+	ps3Report.r2_axis = state[index].pressureR2;
+
+	// Digital button fallbacks: Set digital bits based on analog values
+	// Only set digital bit if analog value is above threshold (> 127)
+	ps3Report.triangle_btn = (state[index].pressureTriangle > 127) ? 1 : 0;
+	ps3Report.circle_btn = (state[index].pressureCircle > 127) ? 1 : 0;
+	ps3Report.cross_btn = (state[index].pressureCross > 127) ? 1 : 0;
+	ps3Report.square_btn = (state[index].pressureSquare > 127) ? 1 : 0;
+	ps3Report.l1_btn = (state[index].pressureL1 > 127) ? 1 : 0;
+	ps3Report.r1_btn = (state[index].pressureR1 > 127) ? 1 : 0;
+	ps3Report.l2_btn = (state[index].pressureL2 > 127) ? 1 : 0;
+	ps3Report.r2_btn = (state[index].pressureR2 > 127) ? 1 : 0;
+
+	return &ps3Report;
+}
 
 SwitchReport *MPG::getSwitchReport(const uint8_t index)
 {
@@ -324,13 +340,9 @@ HIDReport *MPG::getHIDReport(const uint8_t index)
 
 	hidReport.buttons = 0
 		| (pressedB1(index) ? BTN_A      : 0)
-		| (pressedB2(index) ? BTN_B      : 0)
-		| (pressedB3(index) ? BTN_X      : 0)
 		| (pressedB4(index) ? BTN_Y      : 0)
 		| (pressedL1(index) ? BTN_TL     : 0)
 		| (pressedR1(index) ? BTN_TR     : 0)
-		| (pressedL2(index) ? BTN_TL2    : 0)
-		| (pressedR2(index) ? BTN_TR2    : 0)
 		| (pressedS1(index) ? BTN_SELECT : 0)
 		| (pressedS2(index) ? BTN_START  : 0)
 		| (pressedL3(index) ? BTN_THUMBL : 0)
@@ -355,6 +367,11 @@ HIDReport *MPG::getHIDReport(const uint8_t index)
 	hidReport.ly = static_cast<uint8_t>(state[index].ly >> 8);
 	hidReport.rx = static_cast<uint8_t>(state[index].rx >> 8);
 	hidReport.ry = static_cast<uint8_t>(state[index].ry >> 8);
+	
+	hidReport.pressure_circle = 255 - state[index].pressureCircle;
+	hidReport.pressure_square = 255 - state[index].pressureSquare;
+	hidReport.pressure_l2 = 255 - state[index].pressureL2;
+	hidReport.pressure_r2 = 255 - state[index].pressureR2;
 
 	//hidReport.trigger = HID_JOYSTICK_MID;
 


### PR DESCRIPTION
## Summary
This PR adds native analog button support for the Sony DualShock 2 controller, enabling pressure-sensitive functionality for PS2 games via PCSX2 emulation.

## Features
- **Pressure-Sensitive Buttons**: Circle, Square, L2, R2 with full 0-255 analog range
- **Digital Button Preservation**: Triangle, Cross, L1, R1, D-pad, Start, Select, L3, R3 remain digital
- **PCSX2 Compatible**: Proper pressure value inversion for PCSX2
- **Game-Optimized**: Specifically optimized for Metal Gear Solid 2/3
- **OLED Display**: Shows "PS2 ANALOG" for clear firmware identification

## Technical Implementation
Maps 4 analog buttons to available HID axes (after analog sticks use 4 axes):
- **Square** - Gun control  
- **Circle** - CQC
- **L2** - Item menu feathering
- **R2** - Weapon menu feathering

## Testing
- Tested on PCSX2 with Windows and Linux
- Full 8-bit (0-255) pressure resolution working correctly
- Memory usage: 68% flash, 53% RAM

## Files Changed
- `ReflexMPG/Input_Psx.h` - DualShock 2 input handling and analog button enablement
- `ReflexMPG/src/MPG/MPG.cpp` - HID report generation and button mapping  
- `ReflexMPG/ReflexMPG.ino` - OLED display enhancement
- `PS2_Analog_Readme.md` - Documentation for the feature